### PR TITLE
feat: add screenshots on falling tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/ru.yandex.qatools.ashot/ashot -->
+        <dependency>
+            <groupId>ru.yandex.qatools.ashot</groupId>
+            <artifactId>ashot</artifactId>
+            <version>1.5.4</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/base/BaseTest.java
+++ b/src/test/java/base/BaseTest.java
@@ -20,9 +20,4 @@ public class BaseTest {
         System.setProperty("webdriver.chrome.driver", Objects.requireNonNull(getClass().getClassLoader().getResource("drivers/chromedriver.exe")).getFile());
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(10));
     }
-
-    @AfterEach
-    public void close() {
-        driver.quit();
-    }
 }

--- a/src/test/java/base/BaseTest.java
+++ b/src/test/java/base/BaseTest.java
@@ -1,14 +1,16 @@
 package base;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import java.time.Duration;
 import java.util.Objects;
 
 import utils.ChromeDriverOptions;
+import utils.TestListener;
 
+@ExtendWith(TestListener.class)
 public class BaseTest {
 
     public static WebDriver driver;

--- a/src/test/java/tests/LoginTest.java
+++ b/src/test/java/tests/LoginTest.java
@@ -8,13 +8,17 @@ import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.support.Color;
 
 import pages.LoginPage;
 import pages.HomePage;
+import utils.TestListener;
+
 import static utils.DataProperties.readProperty;
 
 
+@ExtendWith(TestListener.class)
 @Epic("Login")
 public class LoginTest extends BaseTest {
 

--- a/src/test/java/tests/LoginTest.java
+++ b/src/test/java/tests/LoginTest.java
@@ -8,17 +8,13 @@ import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.support.Color;
 
 import pages.LoginPage;
 import pages.HomePage;
-import utils.TestListener;
 
 import static utils.DataProperties.readProperty;
 
-
-@ExtendWith(TestListener.class)
 @Epic("Login")
 public class LoginTest extends BaseTest {
 

--- a/src/test/java/tests/LogoutTest.java
+++ b/src/test/java/tests/LogoutTest.java
@@ -8,11 +8,15 @@ import io.qameta.allure.Story;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.extension.ExtendWith;
 import pages.HomePage;
 import pages.LoginPage;
+import utils.TestListener;
+
 import static utils.DataProperties.readProperty;
 
 
+@ExtendWith(TestListener.class)
 @Epic("Logout")
 public class LogoutTest extends BaseTest {
 

--- a/src/test/java/tests/LogoutTest.java
+++ b/src/test/java/tests/LogoutTest.java
@@ -8,15 +8,12 @@ import io.qameta.allure.Story;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.junit.jupiter.api.extension.ExtendWith;
 import pages.HomePage;
 import pages.LoginPage;
-import utils.TestListener;
 
 import static utils.DataProperties.readProperty;
 
 
-@ExtendWith(TestListener.class)
 @Epic("Logout")
 public class LogoutTest extends BaseTest {
 

--- a/src/test/java/tests/UniversalLoginTest.java
+++ b/src/test/java/tests/UniversalLoginTest.java
@@ -4,6 +4,7 @@ import base.BaseTest;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Story;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -11,9 +12,12 @@ import java.util.stream.Stream;
 
 import pages.HomePage;
 import pages.LoginPage;
+import utils.TestListener;
+
 import static utils.DataProperties.readProperty;
 
 
+@ExtendWith(TestListener.class)
 @Epic("parametrized-login")
 public class UniversalLoginTest extends BaseTest {
 

--- a/src/test/java/tests/UniversalLoginTest.java
+++ b/src/test/java/tests/UniversalLoginTest.java
@@ -4,7 +4,6 @@ import base.BaseTest;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Story;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -12,12 +11,10 @@ import java.util.stream.Stream;
 
 import pages.HomePage;
 import pages.LoginPage;
-import utils.TestListener;
 
 import static utils.DataProperties.readProperty;
 
 
-@ExtendWith(TestListener.class)
 @Epic("parametrized-login")
 public class UniversalLoginTest extends BaseTest {
 

--- a/src/test/java/utils/TestListener.java
+++ b/src/test/java/utils/TestListener.java
@@ -16,18 +16,9 @@ import static base.BaseTest.driver;
 
 public class TestListener implements TestWatcher {
 
-    private File getScreenShotFromAShot() throws IOException {
-        File file = new File("screenshot", "tmp.png");
-        Screenshot screenshot = new AShot().takeScreenshot(driver);
-        ImageIO.write(screenshot.getImage(), "png", file);
-        return file;
-    }
-
     @Override
     public void testFailed(ExtensionContext context, Throwable cause) {
-
         File screenshotAs = null;
-
         try {
             screenshotAs = getScreenShotFromAShot();
             Allure.addAttachment("Screenshot", Files.newInputStream(screenshotAs.toPath()));
@@ -53,5 +44,12 @@ public class TestListener implements TestWatcher {
     public void testAborted(ExtensionContext context, Throwable cause) {
         TestWatcher.super.testAborted(context, cause);
         driver.close();
+    }
+
+    private File getScreenShotFromAShot() throws IOException {
+        File file = new File("screenshot", "tmp.png");
+        Screenshot screenshot = new AShot().takeScreenshot(driver);
+        ImageIO.write(screenshot.getImage(), "png", file);
+        return file;
     }
 }

--- a/src/test/java/utils/TestListener.java
+++ b/src/test/java/utils/TestListener.java
@@ -1,0 +1,57 @@
+package utils;
+
+import io.qameta.allure.Allure;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import ru.yandex.qatools.ashot.AShot;
+import ru.yandex.qatools.ashot.Screenshot;
+
+import javax.imageio.ImageIO;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static base.BaseTest.driver;
+
+public class TestListener implements TestWatcher {
+
+    private File getScreenShotFromAShot() throws IOException {
+        File file = new File("screenshot", "tmp.png");
+        Screenshot screenshot = new AShot().takeScreenshot(driver);
+        ImageIO.write(screenshot.getImage(), "png", file);
+        return file;
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+
+        File screenshotAs = null;
+
+        try {
+            screenshotAs = getScreenShotFromAShot();
+            Allure.addAttachment("Screenshot", Files.newInputStream(screenshotAs.toPath()));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        driver.close();
+    }
+
+    @Override
+    public void testDisabled(ExtensionContext context, Optional<String> reason) {
+        TestWatcher.super.testDisabled(context, reason);
+        driver.close();
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        TestWatcher.super.testSuccessful(context);
+        driver.close();
+    }
+
+    @Override
+    public void testAborted(ExtensionContext context, Throwable cause) {
+        TestWatcher.super.testAborted(context, cause);
+        driver.close();
+    }
+}


### PR DESCRIPTION
### UPD 1:
- TestListener расширяет только базовый класс;
- убраны пробелы, приватный метод теперь там, где и должен быть (в конце класса);

UPD 0:
- добавлена поддержка скриншотов (AShot);
- добавлен класс, ответственный за создание скриншотов на падающих тестах и их прикрепление к отчётам (utils/TestListener);
- тестовые классы расширены TestListener (@ExtendWith);
- удалён @AfterEach из BaseTest (driver.close теперь реализован в TestListener);
- на верхний уровень проекта добавлена папка screenshot (необходима для корректной работы в текущей реализации);

Падающие тесты: Login: passwordErrorMessageWithInvalidLengthValues() и hintToEmptyPasswordField();